### PR TITLE
Changes re the MIT license

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,5 +3,5 @@ Version: 1.1
 Author: Matthew Bernstein
 Maintainer: Matthew Bernstein <matthewb@cs.wisc.edu>
 Title: Analysis of Transcript Sequences
-License: None
+License: MIT + file LICENSE
 Description: Simple function for generating histogram of sequence lengths from sequences in a FASTA file

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,2 @@
-The MIT License (MIT)
-
-Copyright (c) 2015 Matthew Bernstein
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+YEAR: 2015
+COPYRIGHT HOLDER: Matthew Bernstein


### PR DESCRIPTION
- CRAN has a quirky set of rules regarding licenses, particularly for
  the MIT license. They want "MIT + file LICENSE" in the License field
  in the DESCRIPTION file, and then just "COPYRIGHT HOLDER" and "YEAR"
  in that LICENSE file.
